### PR TITLE
edit flyout styling in mobile to remove horizontal scrolling

### DIFF
--- a/src/react/flyout-menus/FlyoutMenuNav/styles.scss
+++ b/src/react/flyout-menus/FlyoutMenuNav/styles.scss
@@ -6,7 +6,9 @@
   display: flex;
   justify-content: flex-end;
   flex-grow: 2;
-
+    @include for-md-down {
+    display: block;
+  }
   /*
    * Flyout Menus
    * _________________________________________ */


### PR DESCRIPTION
Fixes [this To Do](https://3.basecamp.com/3097764/buckets/17088607/todos/2666026676)

### Testing notes

1. Refer to in "How to test locally" section in README at https://github.com/growthtools/growth-tools-core to link up core and univeristy
2. Pull latest for university and follow the directions from #1.
3. Run university 
4. Visit [http://localhost:3000](http://localhost:3000)
5. Use dev tools to switch to mobile
6. Check that horizontal scrolling is gone
7. Switch out of mobile view and make sure this fix has not added unwanted styling to desktop
8. For the id #flyout-menu-container, desktop should be display: flex, mobile should be display: block.

### Other information
This fix did not appear to be necessary in the manage app. But I double checked that it did not create any issues there either. 