### PR TITLE
Add brand button mixins

### DIFF
--- a/src/scss/abstracts/_button-classes.scss
+++ b/src/scss/abstracts/_button-classes.scss
@@ -1,0 +1,35 @@
+@import "../abstracts/buttons";
+
+.btn-close {
+  border: none;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: url("/assets/images/icons/close.svg") center no-repeat;
+  background-size: 1.5rem;
+  will-change: transform;
+  transition: transform 0.2s ease-out;
+
+  &:hover {
+    transform: scale(1.15);
+  }
+}
+
+.btn {
+  @include btn;
+}
+.btn.btn-primary {
+  @include btn-primary($white, $university-green);
+}
+.btn.btn-secondary {
+  @include btn-secondary($university-green);
+}
+.btn.btn-tertiary {
+  @include btn-tertiary($university-green);
+}
+.btn.small,
+.btn.btn-sm,
+.input-group-sm .btn {
+  @include btn-small;
+  border-width: 1px;
+  min-height: 31px;
+}

--- a/src/scss/abstracts/_button-classes.scss
+++ b/src/scss/abstracts/_button-classes.scss
@@ -1,4 +1,4 @@
-@import "../abstracts/buttons";
+@import "../abstracts/button-mixins";
 
 .btn-close {
   border: none;

--- a/src/scss/abstracts/_button-mixins.scss
+++ b/src/scss/abstracts/_button-mixins.scss
@@ -1,12 +1,12 @@
-@import "./variables";
+@import "../variables";
 
 /********************
 Usage Example
 ********************
 
-Tertiary buttons have svg icons,
+Tertiary buttons have svg icons, accommodated in example below,
 right/left margins may need to be added to the icon to
-accomodate spacing
+accomodate 8px spacing, see spacing variables for sizes.
 
 ********************
 General Example
@@ -19,12 +19,12 @@ General Example
 
 ********************/
 @mixin btn {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid transparent;
   min-height: 48px;
   font-family: "Brandon Text";
-  align-items: center;
-  justify-content: center;
   border-radius: 6px;
   padding: 0 12px;
   font-size: 20px;
@@ -42,6 +42,7 @@ General Example
   color: $font-color;
   font-weight: bold;
   transition: all 0.2s cubic-bezier(0.19, 1, 0.22, 1);
+  box-shadow: 0 2px 12px 0 rgba($bg-color, 0.25);
 
   a {
     color: $font-color;
@@ -56,7 +57,8 @@ General Example
     background-color: darken($bg-color, 5%);
   }
   &:focus {
-    box-shadow: 0 0 8px 8px rgba($bg-color, 0.2), 0 2px 24px 0 rgba($bg-color, 0.6);
+    box-shadow: 0 0 8px 8px rgba($bg-color, 0.2),
+      0 2px 24px 0 rgba($bg-color, 0.6);
     outline: none;
   }
   &:disabled {
@@ -121,17 +123,4 @@ General Example
 @mixin btn-small {
   font-size: 14px;
   min-height: 32px;
-}
-
-.btn.btn-primary {
-  @include btn-primary($white, $university-green);
-}
-.btn.btn-secondary {
-  @include btn-secondary($university-green);
-}
-.btn.btn-tertiary {
-  @include btn-tertiary($university-green);
-}
-.btn.small {
-  @include btn-small;
 }

--- a/src/scss/abstracts/_buttons.scss
+++ b/src/scss/abstracts/_buttons.scss
@@ -1,0 +1,137 @@
+@import "./variables";
+
+/********************
+Usage Example
+********************
+
+Tertiary buttons have svg icons,
+right/left margins may need to be added to the icon to
+accomodate spacing
+
+********************
+General Example
+********************
+<button class="btn btn-primary">Testing with longer text</button>
+<a href="" class="btn btn-primary">Testing with longer text</a>
+
+<button class="btn btn-primary small">Testing with longer text</button>
+<a href="" class="btn btn-primary small">Testing with longer text</a>
+
+********************/
+@mixin btn {
+  display: flex;
+  border: 1px solid transparent;
+  min-height: 48px;
+  font-family: "Brandon Text";
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  padding: 0 12px;
+  font-size: 20px;
+  font-weight: 500;
+  text-align: center;
+
+  a {
+    text-decoration: none;
+  }
+}
+
+@mixin btn-primary($font-color, $bg-color) {
+  @include btn;
+  background-color: $bg-color;
+  color: $font-color;
+  font-weight: bold;
+  transition: all 0.2s cubic-bezier(0.19, 1, 0.22, 1);
+
+  a {
+    color: $font-color;
+    text-decoration: none;
+  }
+  &:hover {
+    box-shadow: 0 2px 24px 0 rgba($bg-color, 0.7);
+    cursor: pointer;
+    border: 1px solid $bg-color;
+  }
+  &:active {
+    background-color: darken($bg-color, 5%);
+  }
+  &:focus {
+    box-shadow: 0 0 0 8px rgba($bg-color, 0.2), 0 2px 24px 0 rgba($bg-color, 0.6);
+    outline: none;
+  }
+  &:disabled {
+    opacity: 0.2;
+  }
+}
+
+@mixin btn-secondary($color) {
+  @include btn;
+  border: 2px solid $color;
+  background-color: $white;
+  color: $color;
+  a {
+    color: $color;
+  }
+  &:hover {
+    box-shadow: 0 2px 24px 0 rgba($color, 0.7);
+    cursor: pointer;
+  }
+  &:active {
+    background-color: darken($color, 5%);
+  }
+  &:focus {
+    box-shadow: 0 0 0 8px rgba($color, 0.2), 0 2px 24px 0 rgba($color, 0.6);
+    outline: none;
+  }
+  &:disabled {
+    opacity: 0.2;
+  }
+}
+
+@mixin btn-tertiary($color) {
+  @include btn;
+  border-radius: 0.25rem;
+  color: $color;
+  box-shadow: none;
+  width: max-content;
+
+  a {
+    color: $color;
+  }
+
+  .fa {
+    font-size: 16px;
+    color: $color;
+  }
+
+  &:hover {
+    color: $color;
+    cursor: pointer;
+    background-color: lighten($color, 40%);
+  }
+
+  img {
+    height: 1.5em;
+    width: 1.5em;
+    padding-right: 0.2rem;
+    margin-left: -4px;
+  }
+}
+
+@mixin btn-small {
+  font-size: 14px;
+  min-height: 32px;
+}
+
+.btn.btn-primary {
+  @include btn-primary($white, $university-green);
+}
+.btn.btn-secondary {
+  @include btn-secondary($university-green);
+}
+.btn.btn-tertiary {
+  @include btn-tertiary($university-green);
+}
+.btn.small {
+  @include btn-small;
+}

--- a/src/scss/abstracts/_buttons.scss
+++ b/src/scss/abstracts/_buttons.scss
@@ -56,7 +56,7 @@ General Example
     background-color: darken($bg-color, 5%);
   }
   &:focus {
-    box-shadow: 0 0 0 8px rgba($bg-color, 0.2), 0 2px 24px 0 rgba($bg-color, 0.6);
+    box-shadow: 0 0 8px 8px rgba($bg-color, 0.2), 0 2px 24px 0 rgba($bg-color, 0.6);
     outline: none;
   }
   &:disabled {


### PR DESCRIPTION
This PR contains the plain CSS styles & mixins for all Buttons.

1. Link gt-core and university using the instructions in the gt-core README
2. In university, make sure that 
/university/assets/css/abstracts/_buttons.scss and 
/university/assets/css/base/_buttons.scss have been removed
3. Make sure the gt-core scss files have been imported into university in application.scss file
@import "@growth-tools/core/src/scss/abstracts/_button-mixins.scss";
@import "@growth-tools/core/src/scss/abstracts/_button-classes.scss";
4. Visit localhost and see that the buttons are styled

**Notes**:
Is there an even better way to test that these are being imported correctly? Is there a way to actually see that import in the browser network tab or anywhere? 